### PR TITLE
support only files

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,10 +24,16 @@ Walker.prototype._read = function () {
   var self = this
   if (!self._want) return
   self._want = false
-  self._walk(self._dir, function (err) {
+  fs.stat(self._dir, function (err, st) {
+    if (err) return self.emit('error', err)
+    if (!st.isDirectory()) return self._onfile(self._dir, done)
+    self._walk(self._dir, done)
+  })
+
+  function done (err) {
     if (err) return self.emit('error', err)
     self._end()
-  })
+  }
 }
 
 Walker.prototype._walk = function (dir, cb) {

--- a/test.js
+++ b/test.js
@@ -16,6 +16,23 @@ test('test data stream', function (t) {
   })
 })
 
+test('test data stream with only a file', function (t) {
+  var stream = walker(__filename)
+  t.plan(1)
+
+  stream.on('data', function (data) {
+    t.same(data.filepath, __filename)
+  })
+
+  stream.on('error', function (err) {
+    t.ifError(err)
+  })
+
+  stream.on('end', function () {
+    t.end()
+  })
+})
+
 test('test data stream with filter', function (t) {
   function filter (filepath) {
     return false


### PR DESCRIPTION
makes `folderWalker('filename')` emit just the single file