### PR TITLE
Added glob matching and ignore files

### DIFF
--- a/fixtures/.ignore
+++ b/fixtures/.ignore
@@ -1,0 +1,2 @@
+*.ignore
+directory

--- a/fixtures/file.ignore
+++ b/fixtures/file.ignore
@@ -1,0 +1,1 @@
+ignore me

--- a/index.js
+++ b/index.js
@@ -1,13 +1,18 @@
 var from = require('from2')
 var fs = require('fs')
 var path = require('path')
+var minimatch = require('minimatch')
 
 module.exports = walker
 
 function walker (dirs, opts) {
-  var filter = opts && opts.filter || function (filename) { return true }
-  if (!Array.isArray(dirs)) dirs = [dirs]
+  var filter, ignoreFiles = [], ignore = [];
 
+  filter = opts && opts.filter || function (filename) { return true }
+  if (opts && opts.ignoreFiles) ignoreFiles = ignoreFiles.concat(opts.ignoreFiles);
+  if (opts && opts.ignore) ignore = ignore.concat(opts.ignore || []);
+
+  if (!Array.isArray(dirs)) dirs = [dirs]
   dirs = dirs.filter(filter)
 
   var pending = []
@@ -33,9 +38,23 @@ function walker (dirs, opts) {
       fs.readdir(name, function (err, files) {
         if (err) return done(err)
         files.sort()
+
+        // get rules from ignore files for this tree. todo: asynchronize, so that multiple ignoreFiles can load at once.
+        for (var i = ignoreFiles.length - 1; i >= 0; i--) {
+          var ignoreFile = ignoreFiles[i]
+          var index = files.indexOf(ignoreFile)
+          if (index !== -1) {
+            var full = path.join(name, files[index])
+            ignore = ignore.concat(fs.readFileSync(full, { encoding: 'utf-8' }).trim().split('\n'))
+          }
+        }
         for (var i = 0; i < files.length; i++) {
           var next = path.join(name, files[i])
-          if (filter(next)) pending.unshift(next)
+          var relative = path.relative(process.cwd(), next)
+          var matches = ignore.filter(function (rule) {
+            return minimatch(relative, rule, { matchBase: true, dot: true }) || minimatch('/'+relative, rule, { matchBase: true, dot: true })
+          });
+          if (filter(next) && matches.length == 0) pending.unshift(next)
         }
         done(null)
       })

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "homepage": "https://github.com/karissa/folder-walker#readme",
   "dependencies": {
-    "from2": "^2.1.0"
+    "from2": "^2.1.0",
+    "minimatch": "^3.0.0"
   },
   "devDependencies": {
     "tape": "^4.4.0"

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,9 @@ A recursive stream of the files and directories in a given folder. Can take mult
 npm install folder-walker
 ```
 
-## Example
+## Examples
+
+### Multiple folders
 
 ```js
 var walker = require('folder-walker')
@@ -23,7 +25,7 @@ stream.on('data', function (data) {
 
 Example item in the stream:
 
-```
+```js
 {
   basename: 'index.js',
   relname: 'test/index.js',
@@ -32,4 +34,10 @@ Example item in the stream:
   stat: [fs.Stat Object],
   type: 'file' // or 'directory'
 }
+```
+
+### Minimatch Filtering
+
+```js
+var stream = walker('/path/to/folder', { ignore: ['.git', '.dat'], ignoreFiles: ['.gitignore', '.datignore'] })
 ```

--- a/test.js
+++ b/test.js
@@ -99,3 +99,39 @@ test('test data stream filtering out .git', function (t) {
     t.end()
   })
 })
+
+test('test data stream with ignore file .ignore', function (t) {
+  var stream = walker(path.join(__dirname, 'fixtures'), { ignoreFiles: '.ignore' })
+
+  stream.on('data', function (data) {
+    t.equal(data.filepath.indexOf('file.ignore'), -1)
+    console.log(data.filepath)
+    t.equal(data.filepath.indexOf('file'), -1)
+    t.ok(data.stat, 'has stat')
+    t.ok(data.root, 'has root')
+  })
+
+  stream.on('error', function (err) {
+    t.ifError(err)
+  })
+
+  stream.on('end', function () {
+    t.end()
+  })
+})
+
+test('test data stream with minimatch ignore rule', function (t) {
+  var stream = walker(path.join(__dirname, 'fixtures'), { ignore: 'file.ignore' })
+
+  stream.on('data', function (data) {
+    t.equal(data.filepath.indexOf('file.ignore'), -1)
+  })
+
+  stream.on('error', function (err) {
+    t.ifError(err)
+  })
+
+  stream.on('end', function () {
+    t.end()
+  })
+})


### PR DESCRIPTION
I wanted a .datignore file for dat that worked like .gitignore for git. I decided to implement this here in folder-walker rather than just use the filter option so that I didn't have to walk the tree twice to find ignore files. It uses minimatch, the library used internally by npm. 

It's heavier, but allows you to replace

```js
var stream = walker(dirs, {filter: function (data) {
    if (path.basename(data) === '.dat') return false
    return true
}})
```

with

```js
var stream = walker('/path/to/folder', { ignore: ['.dat'], ignoreFiles: ['.datignore'] })
```

and get ignore files along for the ride. 

If you're on board with this, I have a pull request pretty much lined up that adds .datignore support to dat.